### PR TITLE
allow one row prediction

### DIFF
--- a/R/infinitesimalJackknife.R
+++ b/R/infinitesimalJackknife.R
@@ -16,7 +16,7 @@ infJack = function(pred, inbag, calibrate = TRUE, used.trees = NULL) {
                 used.trees = 1:ncol(inbag)
         }
 
-        pred = pred[, used.trees]
+        pred = pred[, used.trees, drop=FALSE]
         
         # check if sampling without replacement
         no.replacement = (max(inbag) == 1)


### PR DESCRIPTION
I am suggesting a slight change to the infJack() function to allow using
the randomForestInfJack() for a single observation. The original version
gives me an error "Error in rowMeans(pred) : 'x' must be an array of at
least two dimensions", if test data contains only one row.