### PR TITLE
fix error integer overflow with large dataset

### DIFF
--- a/R/infinitesimalJackknife.R
+++ b/R/infinitesimalJackknife.R
@@ -26,7 +26,7 @@ infJack = function(pred, inbag, calibrate = TRUE, used.trees = NULL) {
         #
         
         B = length(used.trees)
-        n = nrow(inbag)
+        n = as.numeric(nrow(inbag))
         s = sum(inbag) / ncol(inbag)
 
         y.hat = rowMeans(pred)
@@ -39,7 +39,7 @@ infJack = function(pred, inbag, calibrate = TRUE, used.trees = NULL) {
         # Compute raw infinitesimal jackknife
         #
         
-        if (B^2 > n * nrow(pred)) {
+        if (B^2 > n * as.numeric(nrow(pred))) {
                 
                 C = Matrix::tcrossprod(N, pred.centered) -
                       Matrix::Matrix(N.avg, nrow(N), 1) %*%


### PR DESCRIPTION
Hello,

I was able to use `randomForestInfJack` to calculate variances for your toy example and a 16000 row dataset, but ran into an error using it on a 217000 row dataset:
```
Error in if (B^2 > n * nrow(pred)) { :
  missing value where TRUE/FALSE needed
In addition: Warning message:
In n * nrow(pred) : NAs produced by integer overflow
```
Looking up the issue on [stack overflow](https://stackoverflow.com/questions/17650803/r-simple-multiplication-causes-integer-overflow), figured out it was a simple fix, just needed to change `n` and `nrow(pred)` to class `numeric`. Adding `as.numeric` to lines 29 and 42 fixed the problem for me.

Thanks for your work - I'm pretty excited to see variance estimates for RF.

-Brian